### PR TITLE
デバッグログ関連の調整と変更

### DIFF
--- a/GameData/Game/DebugLog.cpp
+++ b/GameData/Game/DebugLog.cpp
@@ -45,7 +45,7 @@ void DebugLog::DebugLogUpdate()
 			swprintf_s(floatDebug, 256, L"F:%0.2f", float(floatDataIt->second));
 
 			m_debugLog[i].SetText(floatDebug);
-			m_debugLog[i].SetPosition(Vector3{ m_DebugLogPosition.x,m_DebugLogPosition.y - i + 50,m_DebugLogPosition.z });
+			m_debugLog[i].SetPosition(Vector3{ m_DebugLogPosition.x,m_DebugLogPosition.y - i * 50,m_DebugLogPosition.z });
 			m_debugLog[i].SetScale(1.0f);
 			m_debugLog[i].SetColor({ 1.0f, 1.0f, 1.0f, 1.0f });
 		}

--- a/GameData/Game/DebugLog.cpp
+++ b/GameData/Game/DebugLog.cpp
@@ -33,7 +33,7 @@ void DebugLog::DebugLogUpdate()
 			swprintf_s(intDebug, 256, L"I:%d", int(intDataIt->second));
 
 			m_debugLog[i].SetText(intDebug);
-			m_debugLog[i].SetPosition(Vector3{ m_DebugLogPosition.x,m_DebugLogPosition.y - i * 50,m_DebugLogPosition.z });
+			m_debugLog[i].SetPosition(Vector3{ m_debugLogPosition.x,m_debugLogPosition.y - i * 50,m_debugLogPosition.z });
 			m_debugLog[i].SetScale(1.0f);
 			m_debugLog[i].SetColor({ 1.0f, 1.0f, 1.0f, 1.0f });
 		}
@@ -45,7 +45,7 @@ void DebugLog::DebugLogUpdate()
 			swprintf_s(floatDebug, 256, L"F:%0.2f", float(floatDataIt->second));
 
 			m_debugLog[i].SetText(floatDebug);
-			m_debugLog[i].SetPosition(Vector3{ m_DebugLogPosition.x,m_DebugLogPosition.y - i * 50,m_DebugLogPosition.z });
+			m_debugLog[i].SetPosition(Vector3{ m_debugLogPosition.x,m_debugLogPosition.y - i * 50,m_debugLogPosition.z });
 			m_debugLog[i].SetScale(1.0f);
 			m_debugLog[i].SetColor({ 1.0f, 1.0f, 1.0f, 1.0f });
 		}
@@ -57,7 +57,7 @@ void DebugLog::DebugLogUpdate()
 			swprintf_s(vector3Debug, 256, L"X:%0.2f Y:%0.2f Z:%0.2f", float(vector3DataIt->second.x), float(vector3DataIt->second.y), float(vector3DataIt->second.z));
 
 			m_debugLog[i].SetText(vector3Debug);
-			m_debugLog[i].SetPosition(Vector3{ m_DebugLogPosition.x,m_DebugLogPosition.y - i * 50,m_DebugLogPosition.z });
+			m_debugLog[i].SetPosition(Vector3{ m_debugLogPosition.x,m_debugLogPosition.y - i * 50,m_debugLogPosition.z });
 			m_debugLog[i].SetScale(1.0f);
 			m_debugLog[i].SetColor({ 1.0f, 1.0f, 1.0f, 1.0f });
 		}

--- a/GameData/Game/DebugLog.h
+++ b/GameData/Game/DebugLog.h
@@ -64,7 +64,7 @@ private://メンバ変数
 	std::map<std::string, Vector3> m_vector3DebugLogData;//Vector3格納用のデバッグログ用のデータ
 	std::vector<std::string> m_debugLogName;//デバッグログの名前
 	int m_debugLogID = 0;//デバッグログID
-	Vector3 m_DebugLogPosition = Vector3{ 300.0f, 500.0f, 0.0f };//デバッグログの表示位置
+	Vector3 m_debugLogPosition = Vector3{ 300.0f, 500.0f, 0.0f };//デバッグログの表示位置
 	
 private:
 	static DebugLog* m_instance;//シングルトンインスタンス


### PR DESCRIPTION
・float型の変数の数値を表示するログの位置が他の型(int,Vector3)と比べ高く配置していたため修正しました。
・一部の変数名が命名規則違反していたため変更しました。