### PR TITLE
タイトルBGMの不具合修正

### DIFF
--- a/GameData/Game/Title.cpp
+++ b/GameData/Game/Title.cpp
@@ -193,23 +193,23 @@ void Title::TransitionSceneUpdate()
 {
 	float bgmVolume = GameSoundEngine::GetInstance()->GetSoundInstance(GameSoundList_BGM_Title)->GetVolume();
 
-	if (bgmVolume > BGM_VOLUME_NONE)
-	{
-		//タイトル画面BGMの音量を下げる
-		bgmVolume -= BGM_VOLUME_DOWN;
-		GameSoundEngine::GetInstance()->SetVolume(GameSoundList_BGM_Title, bgmVolume);
-	}
-	else
-	{
-		//タイトル画面BGMの音量を0に固定する
-		bgmVolume = BGM_VOLUME_NONE;
-		GameSoundEngine::GetInstance()->SetVolume(GameSoundList_BGM_Title, bgmVolume);
-	}
-
 	//現在の選択
 	switch (m_titleSelect->GetCurrentSelect())
 	{
 	case TitleSelect::enTitleSelect_GameStart:
+		if (bgmVolume > BGM_VOLUME_NONE)
+		{
+			//タイトル画面BGMの音量を下げる
+			bgmVolume -= BGM_VOLUME_DOWN;
+			GameSoundEngine::GetInstance()->SetVolume(GameSoundList_BGM_Title, bgmVolume);
+		}
+		else
+		{
+			//タイトル画面BGMの音量を0に固定する
+			bgmVolume = BGM_VOLUME_NONE;
+			GameSoundEngine::GetInstance()->SetVolume(GameSoundList_BGM_Title, bgmVolume);
+		}
+
 		FadeManager::GetInstance()->SetFadeState(FadeManager::enFadeState_FadeOut);
 		if (FadeManager::GetInstance()->IsFinishFade())
 		{


### PR DESCRIPTION
タイトル画面でゲームスタートを選択した時に流れる演出が終わった後にBGMの音量を下げるはずなのにそれ以外を選択してもBGMの音量が下がる不具合を修正しました。